### PR TITLE
[aws] - Use DescribeLoadBalancers instead of DescribeTags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ require (
 	sigs.k8s.io/structured-merge-diff v0.0.0-20190215000154-7666d3d49c8f // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+go 1.13

--- a/internal/aws/ec2.go
+++ b/internal/aws/ec2.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"strings"
 	"time"
 
@@ -265,11 +266,12 @@ func (c *Cloud) describeInstancesHelper(params *ec2.DescribeInstancesInput) (res
 // StatusEC2 validates EC2 connectivity
 func (c *Cloud) StatusEC2() func() error {
 	return func() error {
-		// MaxResults should be at least 5, which is enforced by EC2 API.
-		in := &ec2.DescribeTagsInput{MaxResults: aws.Int64(5)}
+		in := &elbv2.DescribeLoadBalancersInput{
+			PageSize: aws.Int64(1),
+		}
 
-		if _, err := c.ec2.DescribeTagsWithContext(context.TODO(), in); err != nil {
-			return fmt.Errorf("[ec2.DescribeTagsWithContext]: %v", err)
+		if _, err := c.elbv2.DescribeLoadBalancersWithContext(context.TODO(), in); err != nil {
+			return fmt.Errorf("[elbv2.DescribeLoadBalancersWithContext]: %v", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
> 727006795293.dkr.ecr.us-east-1.amazonaws.com/alb-ingress:bob-ec2status

This moves the load to `DescribeLoadBalancersWithContext`
Currently unsure if calling aws at every health check is a bright idea.
Cutting of that part of the code would make sense if not.