### PR TITLE
Fix resyncs (targetgroup struct, and service.Annotations)

### DIFF
--- a/internal/nlb/ls/rules.go
+++ b/internal/nlb/ls/rules.go
@@ -36,6 +36,13 @@ func buildActions(ctx context.Context, serviceAnnos *annotations.Service, backen
 		backendAction := elbv2.Action{
 			Type:           aws.String(elbv2.ActionTypeEnumForward),
 			TargetGroupArn: aws.String(targetGroup.Arn),
+			ForwardConfig: &elbv2.ForwardActionConfig{
+				TargetGroups: []*elbv2.TargetGroupTuple{
+					{
+						TargetGroupArn: aws.String(targetGroup.Arn),
+					},
+				},
+			},
 		}
 		actions = append(actions, &backendAction)
 	}

--- a/internal/service/controller/reconciler.go
+++ b/internal/service/controller/reconciler.go
@@ -80,11 +80,11 @@ func (r *Reconciler) deleteService(ctx context.Context, serviceKey types.Namespa
 }
 
 func (r *Reconciler) updateServiceAnnotations(ctx context.Context, service *corev1.Service, lbInfo *lb.LoadBalancer) error {
-	if _, ok := service.Annotations["external-dns.alpha.kubernetes.io/target"]; !ok {
-		service.Annotations["external-dns.alpha.kubernetes.io/target"] = lbInfo.DNSName
-		return r.client.Update(ctx, service)
+	if lb, ok := service.Annotations["external-dns.alpha.kubernetes.io/target"]; ok && lb == lbInfo.DNSName {
+		return nil
 	}
-	return nil
+	service.Annotations["external-dns.alpha.kubernetes.io/target"] = lbInfo.DNSName
+	return r.client.Update(ctx, service)
 }
 
 func (r *Reconciler) buildReconcileContext(ctx context.Context, serviceKey types.NamespacedName, service *corev1.Service) context.Context {


### PR DESCRIPTION
Two distinct bugs fixed here:
* A while ago, we changed the way we store the lb name from status.loadBalancer, to an annotation.  The new `updateServiceAnnotations` fails to take into account updates/changes though (it only store at lb creation time).
* We're now receiving our default TG as part of a elbv2.ForwardActionConfig, when re-reading from the live TG.  Which is seen as a change and causes spurious and no-op updates (no functional impact, but that should help with our aws throttling)