### PR TITLE
COMPUTE-1067 Use correct string format for service port (of type `string`)

### DIFF
--- a/internal/nlb/generator/tag.go
+++ b/internal/nlb/generator/tag.go
@@ -44,7 +44,7 @@ func (gen *TagGenerator) TagTG(namespace, serviceName string, servicePort string
 	return map[string]string{
 		TagKeyServiceName:        serviceName,
 		TagKeyServicePort:        servicePort,
-		TagKeyLBCServiceResource: fmt.Sprintf("%s/%s:%d", namespace, serviceName, servicePort),
+		TagKeyLBCServiceResource: fmt.Sprintf("%s/%s:%s", namespace, serviceName, servicePort),
 	}
 }
 


### PR DESCRIPTION
`I0323 18:42:27.773073       6 recorder.go:53] kubebuilder/manager/events "level"=1 "msg"="Warning"  "message"="error tagging arn:aws:elasticloadbalancing:us-east-1:727006795293:targetgroup/nlb-ba8b66ef8181fc1cae8/f4a94987593b94ce due to ValidationError: 1 validation error detected: Value 'elysium-k8s/peter-test:%!d(string=80)' at 'tags.1.member.value' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$\n\tstatus code: 400, request id: 88510348-2c49-44b5-9827-07a80426f67d" "object"={"kind":"Service","namespace":"elysium-k8s","name":"peter-test","uid":"d29aaf5f-951c-40f2-ac2d-993f966c0451","apiVersion":"v1","resourceVersion":"92930065"} "reason"="ERROR"`

> `elysium-k8s/peter-test:%!d(string=80)`